### PR TITLE
GET shorten endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
   #
   namespace :api do
     namespace :v1 do
-      resources :shorten, only: %i[create show]
+      resources :shorten, only: %i[create]
+
+      get 'shorten/:shortcode', to: 'shorten#show'
     end
   end
 end


### PR DESCRIPTION
## Description

This PR enables the client to get the Location from any `Shorten` registered.

Every time that the endpoint is hit and the `shorten` exists, we register a new `redirectCount` for it and update its `lastSeenDate`.